### PR TITLE
Fix default link color

### DIFF
--- a/react/index.scss
+++ b/react/index.scss
@@ -11,6 +11,9 @@ body {
 * {
 	box-sizing: border-box;
 }
+a {
+	color: #51a3dd;
+}
 input {
 	color:black;
 }


### PR DESCRIPTION
Default blue is unreadable on a black background.   
Changed for a lighter one, based on One Piece logo.